### PR TITLE
Fixed ConnectionTimeoutMiddleware config check

### DIFF
--- a/packages/connect-timeout/index.ts
+++ b/packages/connect-timeout/index.ts
@@ -16,7 +16,7 @@ export class ConnectTimeoutMiddleware implements NestMiddleware {
     private static options: connectTimeout.TimeoutOptions;
 
     public resolve(...args: any[]): RequestHandler {
-        if (ConnectTimeoutMiddleware.options) {
+        if (ConnectTimeoutMiddleware.timeout) {
             return connectTimeout(ConnectTimeoutMiddleware.timeout, ConnectTimeoutMiddleware.options);
         } else {
             throw new Error('ConnectTimeoutMiddleware requires a timeout string in configure.');


### PR DESCRIPTION
The `connect-timeout` middleware don't require a `options` argument, but does require the `timeout` argument to be set. This fix changed the check to make sure timeout is set.

I've not committed any changes to the `package-lock.json` or other auto updated changes to configs, as I assume you'll do this when releasing.

PS: Consider adding the npm script `clean` to `postinstall` - I had to fiddle a bit to understand this had to be run.