### PR TITLE
Add missing template types to morgan/index.ts

### DIFF
--- a/packages/morgan/index.ts
+++ b/packages/morgan/index.ts
@@ -1,19 +1,20 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
+import http from 'http';
 import * as morgan from 'morgan';
 
 @Injectable()
 export class MorganMiddleware implements NestMiddleware {
 
-    public static configure(format: string | morgan.FormatFn, opts?: morgan.Options) {
+    public static configure(format: string | morgan.FormatFn, opts?: morgan.Options<http.IncomingMessage, http.ServerResponse>) {
         this.format = format;
         this.options = opts;
     }
 
-    public static token(name: string, callback: morgan.TokenCallbackFn): morgan.Morgan {
+    public static token(name: string, callback: morgan.TokenCallbackFn): morgan.Morgan<http.IncomingMessage, http.ServerResponse> {
         return morgan.token(name, callback);
     }
 
-    private static options: morgan.Options;
+    private static options: morgan.Options<http.IncomingMessage, http.ServerResponse>;
     private static format: string | morgan.FormatFn;
 
     public use(req: any, res: any, next: any) {


### PR DESCRIPTION
I have encountered the same problem described in https://github.com/wbhob/nest-middlewares/issues/35 and this worked for my local installation so I guess this is a proper fix for #35 instead of skipping library type checking.